### PR TITLE
♻️ REFACTOR: use `pydantic` instead of `__init__` constructor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Cache Python dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
+          restore-keys:
+            pip-pre-commit-
+
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |
-          pip install pre-commit pylint==2.6.0
+          pip install -e.[dev]
 
       - name: Run pre-commit
         run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,11 @@ repos:
             '--fail-on-change',
         ]
 
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+
 ## Seems to be conflicting with one of the previous pre-commits (e.g. on the number of empty
 ## lines after a class docstring)
 #-   repo: https://github.com/PyCQA/pydocstyle

--- a/examples/pw_base.py
+++ b/examples/pw_base.py
@@ -4,9 +4,8 @@
 import typing as ty
 import warnings
 
-from qe_tools import CONSTANTS
-
 from aiida import load_profile, orm, plugins
+from qe_tools import CONSTANTS
 
 from aiida_submission_controller import BaseSubmissionController
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 requires-python = ">=3.6"
 
 dependencies = [
-    "aiida-core>=1.0"
+    "aiida-core>=1.0",
+    "pydantic~=1.10.4",
 ]
 
 [project.urls]
@@ -37,6 +38,16 @@ Source = "https://github.com/aiidateam/aiida-submission-controller"
 qe = [
     "aiida-quantumespresso"
 ]
+dev = [
+    "pre-commit~=2.17.0",
+    "pylint-pydantic~=0.1.8"
+]
+
+[tool.pylint.master]
+load-plugins = "pylint_pydantic"
+
+[tool.pylint.'MESSAGES CONTROL']
+extension-pkg-whitelist = "pydantic"
 
 [tool.pylint.format]
 max-line-length = 120


### PR DESCRIPTION
Fixes #9 

Switch to using `pydantic` to annotate the constructor inputs and add validation for some inputs. This makes the code much cleaner and readable, e.g. for the `BaseSubmissionController`:


```python
class BaseSubmissionController(BaseModel):
    """Controller to submit a maximum number of processes (workflows or calculations) at a given time.

    This is an abstract base class: you need to subclass it and define the abstract methods.
    """
    group_label: str
    """Label of the group to store the process nodes in."""
    max_concurrent: int
    """Maximum concurrent active processes."""
```

It's also easy and clear to write validation for the input arguments, e.g. for `group_label`:

```python
def validate_group_exists(value: str) -> str:
    try:
        orm.Group.collection.get(label=value)
    except NotExistent as exc:
        raise ValueError(f'Group with label `{value}` does not exist.') from exc
    else:
        return value

[...]

    _validate_group_exists = validator('group_label', allow_reuse=True)(validate_group_exists)

```

(Note that this validation is a change from the previous `get_or_create` approach. I can revert that, but I think it's the safer approach since silently creating a new group every time an instance of the `BaseSubmissionController` is made with a non-existing group label seems worse than simply having the user pass an existing group.)

The `FromGroupSubmissionController` then becomes:

```Python
class FromGroupSubmissionController(BaseSubmissionController):  # pylint: disable=abstract-method
    """SubmissionController implementation getting data to submit from a parent group.

    This is (still) an abstract base class: you need to subclass it
    and define the abstract methods.
    """
    parent_group_label: str
    """Label of the parent group from which to construct the process inputs."""

    _validate_group_exists = validator('parent_group_label', allow_reuse=True)(validate_group_exists)
```

But with the `pydantic` approach the _full_ signature is shown when using the constructor, it even shows the docstring added for each "field" as you hover over it:

![Screenshot 2023-04-17 at 01 09 10](https://user-images.githubusercontent.com/25607960/232348308-dcd8f2c4-e49c-4d26-a8ce-a1e84aba2bd7.png)

The validation is also quite clear, instead of returning a massive stack trace. E.g. for a little `DummyController` class I wrote:

```python
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-7-8c412ef0bd57> in <module>
----> 1 dcontrol = DummyController(
      2     group_label='non-existent',
      3     max_concurrent=20,
      4     sum_list=[(5, 2), (bool, 3)],
      5     code_label='add@localhost'

~/.virtualenvs/aiida-super/lib/python3.8/site-packages/pydantic/main.cpython-38-x86_64-linux-gnu.so in pydantic.main.BaseModel.__init__()

ValidationError: 1 validation error for DummyController
group_label
  Group with label `non-existent` does not exist. (type=value_error)
```

<details>
<summary>DummyController code</summary>

```python
class DummyController(BaseSubmissionController):
    """Dummy controller for testing purposes."""
    sum_list: List
    code_label: str

    def get_extra_unique_keys(self):
        """The `left_operand` and `right_operand` keys contains the values of the integers to sum."""
        return ('left_operand', 'right_operand')

    def get_all_extras_to_submit(self):
        """Get all the extras, i.e. the list of tuples the user wants to sum the contents of."""
        return self.sum_list

    def get_inputs_and_processclass_from_extras(self, extras_values):
        """Return inputs and process class for the submission of this specific process."""
        code = orm.load_code(self.code_label)
        inputs = {
            'code': code,
            'x': orm.Int(extras_values[0]),
            'y': orm.Int(extras_values[1])
        }
        return inputs, CalculationFactory(code.default_calc_job_plugin)
```

</details>

Other advantages are that it becomes very easy to share a specific controller instance, since `pydantic` models have a `json()` method and hence are easily serialisable and parsable from JSON. 

One down side is that not all field types are supported, e.g. you cannot simply pass a `Code` type to the annotation. Custom fields can be implemented if this is necessary, but I think we can go pretty far with the supported types in `pydantic`.

EDIT: the latter is not an issue, apparently:

https://docs.pydantic.dev/usage/types/#arbitrary-types-allowed