### PR TITLE
Fix `dry_run` in `BaseSubmissionController`.

### DIFF
--- a/aiida_submission_controller/base.py
+++ b/aiida_submission_controller/base.py
@@ -182,7 +182,7 @@ class BaseSubmissionController(BaseModel):
         """Submit a new batch of calculations, ensuring less than self.max_concurrent active at the same time."""
         CMDLINE_LOGGER.level = logging.INFO if verbose else logging.WARNING
 
-        extras_to_run = set(self.get_all_extras_to_submit()).difference(self._check_submitted_extras())
+        extras_to_run = list(set(self.get_all_extras_to_submit()).difference(self._check_submitted_extras()))
 
         if sort:
             extras_to_run = sorted(extras_to_run)


### PR DESCRIPTION
@mbercx Just encountered a small bug when setting `dry_run` to True.

The `submit_new_batch` method fails when setting `dry_run = True`, as it attempts to index a `set` which raises a `TypeError`. This issue is fixed by converting the `set` to a `list`.