### PR TITLE
Add `sleep` argument to `submit_new_batch` and fix `verbose`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.9
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: 'v0.0.262'

--- a/aiida_submission_controller/base.py
+++ b/aiida_submission_controller/base.py
@@ -2,6 +2,7 @@
 """A prototype class to submit processes in batches, avoiding to submit too many."""
 import abc
 import logging
+import time
 from typing import Optional
 
 from aiida import engine, orm
@@ -178,7 +179,7 @@ class BaseSubmissionController(BaseModel):
         """Number of processes that have already been submitted (and might or might not have finished)."""
         return len(self._check_submitted_extras())
 
-    def submit_new_batch(self, dry_run=False, sort=False, verbose=False):
+    def submit_new_batch(self, dry_run=False, sort=False, verbose=False, sleep=0):
         """Submit a new batch of calculations, ensuring less than self.max_concurrent active at the same time."""
         CMDLINE_LOGGER.level = logging.INFO if verbose else logging.WARNING
 
@@ -239,6 +240,8 @@ class BaseSubmissionController(BaseModel):
                 wc_node.set_extra_many(get_extras_dict(self.get_extra_unique_keys(), workchain_extras))
                 self.group.add_nodes([wc_node])
                 submitted[workchain_extras] = wc_node
+                # Only add a delay if the submission was successful
+                time.sleep(sleep)
 
         return submitted
 

--- a/aiida_submission_controller/base.py
+++ b/aiida_submission_controller/base.py
@@ -183,7 +183,8 @@ class BaseSubmissionController(BaseModel):
         """Submit a new batch of calculations, ensuring less than self.max_concurrent active at the same time."""
         CMDLINE_LOGGER.level = logging.INFO if verbose else logging.WARNING
 
-        extras_to_run = list(set(self.get_all_extras_to_submit()).difference(self._check_submitted_extras()))
+        all_extras = set(self.get_all_extras_to_submit())
+        extras_to_run = list(all_extras.difference(self._check_submitted_extras()))
 
         if sort:
             extras_to_run = sorted(extras_to_run)
@@ -204,7 +205,7 @@ class BaseSubmissionController(BaseModel):
             table.add_column("Available", justify="left", style="cyan", no_wrap=True)
 
             table.add_row(
-                str(self.parent_group.count()),
+                str(len(all_extras)),
                 str(self.num_already_run),
                 str(self.num_to_run),
                 str(self.max_concurrent),

--- a/aiida_submission_controller/base.py
+++ b/aiida_submission_controller/base.py
@@ -215,10 +215,10 @@ class BaseSubmissionController(BaseModel):
             console = Console()
             console.print(table)
 
-            if number_to_submit <= 0:
+            if number_to_submit <= 0 or self.num_to_run == 0:
                 print("[bold blue]Info:[/] 😴 Nothing to submit.")
             else:
-                print(f"[bold blue]Info:[/] 🚀 Submitting {number_to_submit} new workchains!")
+                print(f"[bold blue]Info:[/] 🚀 Submitting {min(number_to_submit, self.num_to_run)} new workchains!")
 
         submitted = {}
 


### PR DESCRIPTION
Hi @mbercx!

This PR contains a few small commits. Since they are all very small, I decided to combine them in a single PR.

1. I removed the language version in the `black pre-commit` hook. To the best of my knowledge, this is not really necessary and caused problems when developing in an environment with python 3.10. Please correct me if I'm wrong, so that I can revert this change. (In general, the `.pre-commit-config.yaml` might need to be revisited anyway, as some versions are quite old. Same for the `pyproject.toml`, e.g. do we want to support `aiida 1.0`?)

2. I added an optional sleep argument to enable a possible delay. In the current version, the delay is only used after a successful submission. This closes #11

3. When using the `BaseSubmissionController` and setting `verbose=True`, an error  is raised, as the total number of submissions is determined based on the number of nodes in the `parent_group`, which is a `FromGroupSubmissionController` property only. To fix this, the number of submissions is now determined by the length of `all_extras_to_submit`, which shouldn't change the logic, as the nodes in the `parent_group` are also identified by a unique set of extras.