### PR TITLE
`FromGroupSubmissionController`: enable multiple submissions per parent node

### DIFF
--- a/aiida_submission_controller/from_group.py
+++ b/aiida_submission_controller/from_group.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 from aiida import orm
-from pydantic import validator
+from pydantic import Field, PrivateAttr, validator
 
 from .base import BaseSubmissionController, validate_group_exists
 
@@ -15,6 +15,10 @@ class FromGroupSubmissionController(BaseSubmissionController):  # pylint: disabl
     and define the abstract methods.
     """
 
+    dynamic_extra: dict = Field(default_factory=dict)
+    """A dictionary of dynamic extras to be added to the extras of the process."""
+    unique_extra_keys: tuple = Field(default_factory=tuple)
+    """List of keys defined in the extras that uniquely define each process to be run."""
     parent_group_label: str
     """Label of the parent group from which to construct the process inputs."""
     filters: Optional[dict] = None
@@ -22,29 +26,32 @@ class FromGroupSubmissionController(BaseSubmissionController):  # pylint: disabl
     order_by: Optional[dict] = None
     """Ordering applied to the query of the nodes in the parent group."""
 
+    _dynamic_extra_keys: tuple = PrivateAttr(default_factory=tuple)
+    _dynamic_extra_values: tuple = PrivateAttr(default_factory=tuple)
+
     _validate_group_exists = validator("parent_group_label", allow_reuse=True)(validate_group_exists)
+
+    def __init__(self, **kwargs):
+        """Initialize the instance."""
+        super().__init__(**kwargs)
+
+        if self.dynamic_extra:
+            self._dynamic_extra_keys, self._dynamic_extra_values = zip(*self.dynamic_extra.items())
 
     @property
     def parent_group(self):
         """Return the AiiDA ORM Group instance of the parent group."""
         return orm.Group.objects.get(label=self.parent_group_label)
 
-    def get_parent_node_from_extras(self, extras_values):
-        """Return the Node instance (in the parent group) from the (unique) extras identifying it."""
-        extras_projections = self.get_process_extra_projections()
-        assert len(extras_values) == len(extras_projections), f"The extras must be of length {len(extras_projections)}"
-        filters = dict(zip(extras_projections, extras_values))
+    def get_extra_unique_keys(self):
+        """Return a tuple of the keys of the unique extras that will be used to uniquely identify your workchains."""
+        # `_parent_uuid` will be replaced by the `uuid` attribute in the queries
+        combined_extras = ["_parent_uuid"] + list(self.unique_extra_keys) + list(self._dynamic_extra_keys)
+        return tuple(combined_extras)
 
-        qbuild = orm.QueryBuilder()
-        qbuild.append(orm.Group, filters={"id": self.parent_group.pk}, tag="group")
-        qbuild.append(orm.Node, project="*", filters=filters, tag="process", with_group="group")
-        qbuild.limit(2)
-        results = qbuild.all(flat=True)
-        if len(results) != 1:
-            raise ValueError(
-                "I would have expected only 1 result for extras={extras}, I found {'>1' if len(qbuild) else '0'}"
-            )
-        return results[0]
+    def get_parent_node_from_extras(self, extras_values):
+        """Return the Node instance (in the parent group) from the `uuid` identifying it."""
+        return orm.load_node(extras_values[0])
 
     def get_all_extras_to_submit(self):
         """Return a *set* of the values of all extras uniquely identifying all simulations that you want to submit.
@@ -57,11 +64,15 @@ class FromGroupSubmissionController(BaseSubmissionController):  # pylint: disabl
         """
         extras_projections = self.get_process_extra_projections()
 
+        # Use only the unique extras (and the parent uuid) to identify the processes to be submitted
+        if self._dynamic_extra_keys:
+            extras_projections = extras_projections[: -len(self._dynamic_extra_keys)]
+
         qbuild = orm.QueryBuilder()
         qbuild.append(orm.Group, filters={"id": self.parent_group.pk}, tag="group")
         qbuild.append(
             orm.Node,
-            project=extras_projections,
+            project=["uuid"] + extras_projections[1:],  # Replace `_parent_uuid` with `uuid`
             filters=self.filters,
             tag="process",
             with_group="group",
@@ -76,10 +87,12 @@ class FromGroupSubmissionController(BaseSubmissionController):  # pylint: disabl
         # First, however, convert to a list of tuples otherwise
         # the inner lists are not hashable
         results = [tuple(_) for _ in results]
-        for res in results:
+        for i, res in enumerate(results):
             assert all(
                 extra is not None for extra in res
             ), "There is at least one of the nodes in the parent group that does not define one of the required extras."
+            results[i] = (*res, *self._dynamic_extra_values)  # Add the dynamic extras to the results
+
         results_set = set(results)
 
         assert len(results) == len(results_set), "There are duplicate extras in the parent group"


### PR DESCRIPTION
Hi @mbercx!

I saw #15 and I was also thinking about that issue while using the submission controllers. As I think that this feature would be very useful, I started to draft a possible solution so that we have something to discuss and a starting point (I just realized that my ideas are quite similar to what you mentioned in #5 back then).

The main idea was to introduce so-called `dynamic_extras`. These extras are only used to define the processes that should be submitted, in addition to the `unique_extra_keys`. Therefore, these keys are also excluded when querying for parent nodes. As an example, one could set `dynamic_extra = {'ecutrho': 400, 'ecutwfc': 100}` in a convergence study. I've already tested the logic and it seems to work. 

One point that needs to be discussed is the logic to identify the parent nodes. I decided to only use the `uuid` to identify the parent nodes, as it's unique per definition. Personally, I found it a bit cumbersome to always take care of setting the extras to identify the nodes in the `parent_group`. From my perspective, one takes care of this by collecting certain nodes in a group.

However, also mentioned in #5, the extras are passed in subsequent runs, which is a nice feature. Therefore, I still kept the `unique_extra_keys` as an optional argument, so that the user can specify extras that are passed. If we keep this logic, one can think of changing the name of `unique_extra_keys`, as they are not used to uniquely identify the parent nodes.

Of course, we can also make the `uuid` the default `unique_extra_keys` to identify the parent nodes and in case the user provides explicit `unique_extra_keys`, these are used. Again, personally, I don't really see a reason why not always using the `uuid` (as the advantages of the extras are still preserved in this version). But please convince me of the opposite 😄 
As always, I'm more than happy to discuss this.

Doc-strings will be updated once we agreed on a final logic.