### PR TITLE
update dependencies

### DIFF
--- a/aiida_submission_controller/base.py
+++ b/aiida_submission_controller/base.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from aiida import engine, orm
 from aiida.common import NotExistent
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 from rich import print
 from rich.console import Console
 from rich.table import Table
@@ -56,12 +56,12 @@ class BaseSubmissionController(BaseModel):
     unique_extra_keys: Optional[tuple] = None
     """Tuple of keys defined in the extras that uniquely define each process to be run."""
 
-    _validate_group_exists = validator("group_label", allow_reuse=True)(validate_group_exists)
+    _validate_group_exists = field_validator("group_label")(validate_group_exists)
 
     @property
     def group(self):
         """Return the AiiDA ORM Group instance that is managed by this class."""
-        return orm.Group.objects.get(label=self.group_label)
+        return orm.Group.collection.get(label=self.group_label)
 
     def get_query(self, process_projections, only_active=False):
         """Return a QueryBuilder object to get all processes in the group associated to this.
@@ -236,7 +236,7 @@ class BaseSubmissionController(BaseModel):
             else:
                 CMDLINE_LOGGER.report(f"Submitted work chain <{wc_node}> for extras <{workchain_extras}>.")
 
-                wc_node.set_extra_many(get_extras_dict(self.get_extra_unique_keys(), workchain_extras))
+                wc_node.base.extras.set_many(get_extras_dict(self.get_extra_unique_keys(), workchain_extras))
                 self.group.add_nodes([wc_node])
                 submitted[workchain_extras] = wc_node
 

--- a/aiida_submission_controller/from_group.py
+++ b/aiida_submission_controller/from_group.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 from aiida import orm
-from pydantic import validator
+from pydantic import field_validator
 
 from .base import BaseSubmissionController, validate_group_exists
 
@@ -22,12 +22,12 @@ class FromGroupSubmissionController(BaseSubmissionController):  # pylint: disabl
     order_by: Optional[dict] = None
     """Ordering applied to the query of the nodes in the parent group."""
 
-    _validate_group_exists = validator("parent_group_label", allow_reuse=True)(validate_group_exists)
+    _validate_group_exists = field_validator("parent_group_label")(validate_group_exists)
 
     @property
     def parent_group(self):
         """Return the AiiDA ORM Group instance of the parent group."""
-        return orm.Group.objects.get(label=self.parent_group_label)
+        return orm.Group.collection.get(label=self.parent_group_label)
 
     def get_parent_node_from_extras(self, extras_values):
         """Return the Node instance (in the parent group) from the (unique) extras identifying it."""

--- a/examples/add_in_batches.py
+++ b/examples/add_in_batches.py
@@ -2,9 +2,9 @@
 """An example of a SubmissionController implementation to compute a 12x12 table of additions."""
 import time
 
-from aiida import orm
+from aiida import load_profile, orm
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
-from pydantic import validator
+from pydantic import field_validator
 
 from aiida_submission_controller import BaseSubmissionController
 
@@ -15,7 +15,7 @@ class AdditionTableSubmissionController(BaseSubmissionController):
     code_label: str
     """Label of the `code.arithmetic.add` `Code`."""
 
-    @validator("code_label")
+    @field_validator("code_label")
     def _check_code_plugin(cls, value):
         plugin_type = orm.load_code(value).default_calc_job_plugin
         if plugin_type == "core.arithmetic.add":
@@ -63,8 +63,9 @@ def main():
     ##
     ##  verdi code setup -L add --on-computer --computer=localhost -P core.arithmetic.add --remote-abs-path=/bin/bash -n
     # Create a controller
+    load_profile()
 
-    group, _ = orm.Group.objects.get_or_create(label="tests/addition_table")
+    group, _ = orm.Group.collection.get_or_create(label="tests/addition_table")
 
     controller = AdditionTableSubmissionController(
         code_label="add@localhost",
@@ -122,6 +123,9 @@ def main():
             sys.stdout.write("\n")
 
         time.sleep(10)
+
+        if controller.num_to_run == 0:
+            break
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core>=3.4,<4"]
+requires = ["flit_core>=3.9,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -20,15 +20,16 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8"
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 
 dependencies = [
-    "aiida-core>=1.0",
-    "pydantic~=1.10.4",
+    "aiida-core>=2.6",
+    "pydantic~=2.8.2",
     "rich",
 ]
 
@@ -40,8 +41,8 @@ qe = [
     "aiida-quantumespresso"
 ]
 dev = [
-    "pre-commit~=2.17.0",
-    "pylint-pydantic~=0.1.8"
+    "pre-commit~=3.8.0",
+    "pylint-pydantic~=0.3.2"
 ]
 
 [tool.black]


### PR DESCRIPTION
The repo is outdated with respect to `aiida-core v2.6`

I need this update to perform some performance test for `aiida-firecrest`

The main changes in this PR are as follows:
- $\to$ `aiida-core v2.6`
  -  `orm.Group.objects.get` $\to$ `orm.Group.collection.get`
  -  `orm.Group.objects.get_or_create` $\to$ `orm.Group.collection.get_or_create`

- $\to$ `pydantic v2.8.2`:
  - `@validator` $\to$ `@field_validator`
  - ~`allow_reuse=True`~  [not needed anymore](https://errors.pydantic.dev/2.8/migration/ )

- `/examples/add_in_batches.py` 
  - added `load_profile()`
  - a condition to break the loop once everything is calculated.